### PR TITLE
New tube segmentation method developed

### DIFF
--- a/brainlit/algorithms/generate_fragments/adaptive_thresh.py
+++ b/brainlit/algorithms/generate_fragments/adaptive_thresh.py
@@ -1,7 +1,6 @@
 # Reference: http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/Python_html/300_Segmentation_Overview.html
 
 import brainlit
-from brainlit.utils.session import NeuroglancerSession
 import SimpleITK as sitk
 from sklearn.mixture import GaussianMixture
 import numpy as np

--- a/brainlit/algorithms/generate_fragments/tube_seg.py
+++ b/brainlit/algorithms/generate_fragments/tube_seg.py
@@ -2,6 +2,11 @@ import numpy as np
 from skimage import draw
 import itertools
 from scipy.ndimage.morphology import distance_transform_edt
+from typing import Optional, List, Tuple, Union
+from scipy.ndimage.morphology import distance_transform_edt
+from skimage import draw
+from brainlit.utils.util import check_type, check_size, check_iterable_type
+from tqdm import tqdm
 
 
 def pairwise(iterable):
@@ -141,4 +146,62 @@ def tubes_seg(img, vertices, radius, spheres=False):
         else:
             output += draw_tube_from_edt(img, a, b, radius)
     labels = np.where(output >= 1, 1, 0)
+    return labels
+
+
+def tubes_from_paths(
+    size: Tuple[int, int, int],
+    paths: List[List[int]],
+    radius: Optional[Union[float, int]] = None,
+):
+    """Constructs tubes from list of paths.
+    Returns densely labeled paths within the shape of the image.
+
+    Arguments:
+        size: The size of image to consider.
+        paths: The list of paths. Each path is a list of points along the path (non-dense).
+        radius: The radius of the line to draw. Default is None = 1 pixel wide line.
+    """
+    check_size(size)
+    for path in paths:
+        [check_iterable_type(vert, (int, np.integer)) for vert in path]
+    if radius is not None:
+        check_type(radius, (int, float))
+        if radius <= 0:
+            raise ValueError(f"Radius {radius} must be positive, not.")
+
+    def _within_img(line, size):
+        arrline = np.array(line).astype(int)
+        arrline = arrline[:, arrline[0, :] < size[0]]
+        arrline = arrline[:, arrline[0, :] >= 0]
+        arrline = arrline[:, arrline[1, :] < size[1]]
+        arrline = arrline[:, arrline[1, :] >= 0]
+        arrline = arrline[:, arrline[2, :] < size[2]]
+        arrline = arrline[:, arrline[2, :] >= 0]
+        return (arrline[0, :], arrline[1, :], arrline[2, :])
+
+    coords = [[], [], []]
+    for path in tqdm(paths):
+        for i in range(len(path) - 1):
+            line = draw.line_nd(path[i], path[i + 1])
+            line = _within_img(line, size)
+            if len(line) > 0:
+                coords[0] = np.concatenate((coords[0], line[0]))
+                coords[1] = np.concatenate((coords[1], line[1]))
+                coords[2] = np.concatenate((coords[2], line[2]))
+
+    try:
+        coords = (coords[0].astype(int), coords[1].astype(int), coords[2].astype(int))
+    except AttributeError:  # if a list was passed
+        coords = (coords[0], coords[1], coords[2])
+
+    if radius is not None:
+        line_array = np.ones(size, dtype=int)
+        line_array[coords] = 0
+        seg = distance_transform_edt(line_array)
+        labels = np.where(seg <= radius, 1, 0)
+    else:
+        labels = np.zeros(size, dtype=int)
+        labels[coords] = 1
+
     return labels

--- a/brainlit/utils/session.py
+++ b/brainlit/utils/session.py
@@ -7,18 +7,18 @@ from cloudvolume import CloudVolume, view
 from cloudvolume.lib import Bbox
 from cloudvolume.exceptions import InfoUnavailableError
 from pathlib import Path
-from .swc import read_s3, df_to_graph, get_sub_neuron, graph_to_paths
+from brainlit.utils.swc import read_s3, df_to_graph, get_sub_neuron, graph_to_paths
+from brainlit.algorithms.generate_fragments.tube_seg import tubes_from_paths
 import napari
 import warnings
 import networkx as nx
 from typing import Optional, List, Union, Tuple, Literal
-from .util import (
+from brainlit.utils.util import (
     check_type,
     check_size,
     check_precomputed,
     check_iterable_type,
     check_iterable_nonnegative,
-    tubes_from_paths,
 )
 
 Bounds = Union[Bbox, Tuple[int, int, int, int, int, int]]
@@ -149,6 +149,8 @@ class NeuroglancerSession:
         Returns:
             labels: A volume within the bounding box, with 1 on tubes and 0 elsewhere.
         """
+        if self.cv_segments is None:
+            raise ValueError("Cannot get segments without segmentation data.")
         check_type(seg_id, int)
         if radius is not None:
             check_type(radius, (int, float))
@@ -159,6 +161,8 @@ class NeuroglancerSession:
         paths = graph_to_paths(G)
         if isinstance(bbox, Bbox):
             bbox = bbox.to_list()
+        check_iterable_type(bbox, (int, np.integer))
+        check_iterable_nonnegative(bbox)
         labels = tubes_from_paths(np.subtract(bbox[3:], bbox[:3]), paths, radius)
         return labels
 

--- a/brainlit/utils/util.py
+++ b/brainlit/utils/util.py
@@ -1,11 +1,8 @@
 import contextlib
 import joblib
 from pathlib import Path
-from typing import Optional, List, Tuple
 from tqdm import tqdm
 import numpy as np
-from scipy.ndimage.morphology import distance_transform_edt
-from skimage import draw
 
 
 @contextlib.contextmanager
@@ -52,13 +49,13 @@ def check_iterable_nonnegative(input):
 
 
 def check_size(input, allow_float=True):
-    check_type(input, (list, tuple))
+    check_type(input, (list, tuple, np.ndarray))
     if len(input) != 3:
         raise ValueError(f"{input} must have x, y, z dimensions")
     if allow_float:
-        check_iterable_type(input, (int, float))
+        check_iterable_type(input, (int, np.integer, float))
     else:
-        check_iterable_type(input, int)
+        check_iterable_type(input, (int, np.integer))
 
 
 def check_precomputed(input):
@@ -73,52 +70,3 @@ def check_binary_path(input):
     for bcode in input:
         if not all(c in "01" for c in bcode):
             raise ValueError(f"Binary paths are made of 0s and 1s, not like {bin}")
-
-
-def tubes_from_paths(
-    size: Tuple[int, int, int], paths: List[List[int]], radius: Optional[int] = None
-):
-    """Constructs tubes from list of paths.
-    Returns densely labeled paths within the shape of the image.
-
-    Arguments:
-        size: The size of image to consider.
-        paths: The list of paths. Each path is a list of points along the path (non-dense).
-        radius: The radius of the line to draw. Default is None = 1 pixel wide line.
-    """
-
-    def _within_img(line, size):
-        arrline = np.array(line).astype(int)
-        arrline = arrline[:, arrline[0, :] < size[0]]
-        arrline = arrline[:, arrline[0, :] >= 0]
-        arrline = arrline[:, arrline[1, :] < size[1]]
-        arrline = arrline[:, arrline[1, :] >= 0]
-        arrline = arrline[:, arrline[2, :] < size[2]]
-        arrline = arrline[:, arrline[2, :] >= 0]
-        return (arrline[0, :], arrline[1, :], arrline[2, :])
-
-    coords = [[], [], []]
-    for path in tqdm(paths):
-        for i in range(len(path) - 1):
-            line = draw.line_nd(path[i], path[i + 1])
-            line = _within_img(line, size)
-            if len(line) > 0:
-                coords[0] = np.concatenate((coords[0], line[0]))
-                coords[1] = np.concatenate((coords[1], line[1]))
-                coords[2] = np.concatenate((coords[2], line[2]))
-
-    try:
-        coords = (coords[0].astype(int), coords[1].astype(int), coords[2].astype(int))
-    except AttributeError:
-        coords = (coords[0], coords[1], coords[2])
-
-    if radius is not None:
-        line_array = np.ones(size, dtype=int)
-        line_array[coords] = 0
-        seg = distance_transform_edt(line_array)
-        labels = np.where(seg <= radius, 1, 0)
-    else:
-        labels = np.zeros(size, dtype=int)
-        labels[coords] = 1
-
-    return labels

--- a/brainlit/utils/util.py
+++ b/brainlit/utils/util.py
@@ -1,6 +1,11 @@
 import contextlib
 import joblib
 from pathlib import Path
+from typing import Optional, List, Tuple
+from tqdm import tqdm
+import numpy as np
+from scipy.ndimage.morphology import distance_transform_edt
+from skimage import draw
 
 
 @contextlib.contextmanager
@@ -68,3 +73,52 @@ def check_binary_path(input):
     for bcode in input:
         if not all(c in "01" for c in bcode):
             raise ValueError(f"Binary paths are made of 0s and 1s, not like {bin}")
+
+
+def tubes_from_paths(
+    size: Tuple[int, int, int], paths: List[List[int]], radius: Optional[int] = None
+):
+    """Constructs tubes from list of paths.
+    Returns densely labeled paths within the shape of the image.
+
+    Arguments:
+        size: The size of image to consider.
+        paths: The list of paths. Each path is a list of points along the path (non-dense).
+        radius: The radius of the line to draw. Default is None = 1 pixel wide line.
+    """
+
+    def _within_img(line, size):
+        arrline = np.array(line).astype(int)
+        arrline = arrline[:, arrline[0, :] < size[0]]
+        arrline = arrline[:, arrline[0, :] >= 0]
+        arrline = arrline[:, arrline[1, :] < size[1]]
+        arrline = arrline[:, arrline[1, :] >= 0]
+        arrline = arrline[:, arrline[2, :] < size[2]]
+        arrline = arrline[:, arrline[2, :] >= 0]
+        return (arrline[0, :], arrline[1, :], arrline[2, :])
+
+    coords = [[], [], []]
+    for path in tqdm(paths):
+        for i in range(len(path) - 1):
+            line = draw.line_nd(path[i], path[i + 1])
+            line = _within_img(line, size)
+            if len(line) > 0:
+                coords[0] = np.concatenate((coords[0], line[0]))
+                coords[1] = np.concatenate((coords[1], line[1]))
+                coords[2] = np.concatenate((coords[2], line[2]))
+
+    try:
+        coords = (coords[0].astype(int), coords[1].astype(int), coords[2].astype(int))
+    except AttributeError:
+        coords = (coords[0], coords[1], coords[2])
+
+    if radius is not None:
+        line_array = np.ones(size, dtype=int)
+        line_array[coords] = 0
+        seg = distance_transform_edt(line_array)
+        labels = np.where(seg <= radius, 1, 0)
+    else:
+        labels = np.zeros(size, dtype=int)
+        labels[coords] = 1
+
+    return labels

--- a/docs/notebooks/pipelines/tubes.ipynb
+++ b/docs/notebooks/pipelines/tubes.ipynb
@@ -1,0 +1,79 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": 3
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python_defaultSpec_1597294299559",
+   "display_name": "Python 3.8.3 64-bit ('brainlit3.8': conda)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from brainlit.utils import session\n",
+    "import napari"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"s3://mouse-light-viz/precomputed_volumes/brain1\"\n",
+    "sess = session.NeuroglancerSession(url=url, url_segments=url+\"_segments\", mip=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": "Downloading: 100%|██████████| 1/1 [00:00<00:00,  4.87it/s]\nDownloading:   0%|          | 0/1 [00:00<?, ?it/s]\n"
+    }
+   ],
+   "source": [
+    "img, _, vert = sess.pull_chunk(2, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with napari.gui_qt():\n",
+    "    viewer = napari.view_image(img, ndisplay=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/docs/notebooks/utils/uploading_brains.ipynb
+++ b/docs/notebooks/utils/uploading_brains.ipynb
@@ -9,7 +9,8 @@
    "outputs": [],
    "source": [
     "from brainlit.utils import upload, session\n",
-    "from pathlib import Path"
+    "from pathlib import Path\n",
+    "import napari"
    ]
   },
   {
@@ -53,20 +54,21 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": "Creating precomputed volume: 100%|██████████| 1/1 [00:05<00:00,  5.18s/it]\nCreating precomputed volume:   0%|          | 0/8 [00:00<?, ?it/s]\nFinished mip 0, took 5.183950901031494 seconds\nCreating precomputed volume:  62%|██████▎   | 5/8 [00:12<00:07,  2.38s/it]"
-    }
-   ],
+   "outputs": [],
    "source": [
     "upload.upload_volumes(source, dest, num_res)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3) Upload the segmentation data."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "tags": []
    },
@@ -76,71 +78,36 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "_, _, voxel_size, img_size, _ = upload.get_volume_info(source, num_res)\n",
-    "upload.create_cloud_volume(dest_annotation, img_size, voxel_size, 1, layer_type=\"annotation\")"
+    "## Download the data with NeuroglancerSession and generate labels."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
     "%%capture\n",
-    "from brainlit.utils.session import NeuroglancerSession\n",
-    "from brainlit.algorithms.generate_fragments.tube_seg import tubes_seg\n",
-    "sess = NeuroglancerSession(url = dest, url_segments= dest_segments, url_annotation=dest_annotation, mip=0)\n",
-    "img, bounds, vertices = sess.pull_vertex_list(2, range(100, 200), expand=True)  # get image containing some data\n",
-    "labels = tubes_seg(img, vertices, radius=.1)  # generate labels via tube segmentation\n",
-    "sess.push(labels, bounds)  # push labels"
+    "sess = session.NeuroglancerSession(url=dest, url_segments=dest_segments, mip=0)  # create session object object\n",
+    "img, bounds, vertices = sess.pull_vertex_list(2, range(250, 350), expand=True)  # get image containing some data\n",
+    "labels = sess.create_tubes(2, bounds, radius=1)  # generate labels via tube segmentation"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Visualize your data with NeuroglancerSession and napari"
+    "## 4) Visualize the data with napari"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from cloudvolume import Bbox\n",
-    "from brainlit.utils.swc import graph_to_paths\n",
-    "import napari"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": "Downloading: 100%|██████████| 1/1 [00:00<00:00, 518.46it/s]\n"
-    }
-   ],
-   "source": [
-    "G_sub = sess.get_segments(2, bounds)\n",
-    "paths = graph_to_paths(G_sub)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
    "metadata": {
     "tags": []
    },
@@ -149,8 +116,7 @@
     "with napari.gui_qt():\n",
     "    viewer = napari.Viewer(ndisplay=3)\n",
     "    viewer.add_image(img)\n",
-    "    viewer.add_labels(labels)\n",
-    "    viewer.add_shapes(data=paths, shape_type='path', edge_width=0.1, edge_color='blue', opacity=0.1)"
+    "    viewer.add_labels(labels)"
    ]
   },
   {
@@ -165,7 +131,7 @@
   "kernelspec": {
    "display_name": "Python 3.8.3 64-bit ('brainlit3.8': conda)",
    "language": "python",
-   "name": "python_defaultSpec_1596934409212"
+   "name": "python_defaultSpec_1597187782236"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tests/test_tube_seg.py
+++ b/tests/test_tube_seg.py
@@ -279,4 +279,3 @@ def test_tubes_exact():
     for i in range(10):  # set middle column to zero
         tubes[5, 5, i] = 0
     assert (tubes == 0).all()  # now everything should be zero
-

--- a/tests/test_tube_seg.py
+++ b/tests/test_tube_seg.py
@@ -266,3 +266,17 @@ def test_tubes_from_paths():
     size = np.subtract(bbox[3:], bbox[:3])
     tubes = tube_seg.tubes_from_paths(size, paths)
     assert (tubes != 0).any()
+
+
+def test_tubes_exact():
+    """Tests that exact pixels are filled in.
+    """
+    img = np.zeros((10, 10, 10))
+    verts = [[5, 5, 0], [5, 5, 10]]
+    tubes = tube_seg.tubes_from_paths(img.shape, [verts])
+    assert tubes.shape == img.shape
+    assert (tubes[5, 5, :] == 1).all()
+    for i in range(10):  # set middle column to zero
+        tubes[5, 5, i] = 0
+    assert (tubes == 0).all()  # now everything should be zero
+


### PR DESCRIPTION
Unfortunately the existing methods seemed unoptimized for large amounts of segmentation data, so I created a new method which runs more efficiently.

I added this method, `tubes_from_paths`, [here](https://github.com/neurodata/brainlit/blob/tube-connections/brainlit/utils/util.py#L78-L124).

I incorporated it into a `NeuroglancerSession` object via the `create_tubes` method [here](https://github.com/neurodata/brainlit/blob/tube-connections/brainlit/utils/session.py#L138-L163).

I still need to add tests typechecking and verifying output.

A notebook demonstrating functionality can be run [here](https://github.com/neurodata/brainlit/blob/tube-connections/docs/notebooks/utils/uploading_brains.ipynb).