### PR TITLE
Fix BinaryDilate in adaptive_thresh.py to support SimpleITK 2.x

### DIFF
--- a/brainlit/algorithms/generate_fragments/adaptive_thresh.py
+++ b/brainlit/algorithms/generate_fragments/adaptive_thresh.py
@@ -189,7 +189,7 @@ def level_set_seg(
     seg = sitk.Image(img_T1_255.GetSize(), sitk.sitkUInt8)
     seg.CopyInformation(img_T1_255)
     seg[seed] = 1
-    seg = sitk.BinaryDilate(seg, 1)
+    seg = sitk.BinaryDilate(seg, [1]*seg.GetDimension())
 
     stats = sitk.LabelStatisticsImageFilter()
     stats.Execute(img_T1_255, seg)
@@ -251,7 +251,7 @@ def connected_threshold(img, seed, lower_threshold=None, upper_threshold=255):
     # seg[seed] = 1
     for s in seed:
         seg[s] = 1
-    seg = sitk.BinaryDilate(seg, 1)
+    seg = sitk.BinaryDilate(seg, [1]*seg.GetDimension())
 
     if lower_threshold == None:
         lower_threshold = thres_from_gmm(img)
@@ -316,7 +316,7 @@ def confidence_connected_threshold(
     # seg[seed] = 1
     for s in seed:
         seg[s] = 1
-    seg = sitk.BinaryDilate(seg, 1)
+    seg = sitk.BinaryDilate(seg, [1]*seg.GetDimension())
 
     seg_con = sitk.ConfidenceConnected(
         img_T1_255,
@@ -370,7 +370,7 @@ def neighborhood_connected_threshold(
     seg.CopyInformation(img_T1)
     for s in seed:
         seg[s] = 1
-    seg = sitk.BinaryDilate(seg, 1)
+    seg = sitk.BinaryDilate(seg, [1]*seg.GetDimension())
 
     if lower_threshold == None:
         lower_threshold = thres_from_gmm(img)


### PR DESCRIPTION
The arguments to the SimpleITK BinaryDilate method changed in SimpleITK 2.x. This method is used several times in `brainlit/algorithms/generate_fragments/adaptive_thresh.py`, this pull request addresses the update.

The change is as follows, from section 12.1.3 of https://readthedocs.org/projects/simpleitk/downloads/pdf/release/:

> The procedural interfaces for morphology filters only accept vector values for the radius parameter. Previously the
> procedures accepted a scalar for the radius parameter. For example, a structuring element of radius 5 used on a 3D
> image is specified as `[5, 5, 5]`:
> 
> 1.x:
> `seg = sitk.BinaryDilate(seg, 5) `
> 2.x:
> `seg = sitk.BinaryDilate(seg, [5]*seg.GetDimension())`