### PR TITLE
return _get_voxel() output

### DIFF
--- a/brainlit/utils/session.py
+++ b/brainlit/utils/session.py
@@ -203,7 +203,7 @@ class NeuroglancerSession:
             img: A 2*nx+1 X 2*ny+1 X 2*nz+1 volume.
             bounds: Bounding box object which contains the bounds of the volume.
             vox_in_img: List of coordinates which locate the initial point in the subvolume.
-            voxel: List of coordinate which locate the initial point in the whole volume.
+            voxel: List of coordinates which locate the initial point within the original volume.
         """
         check_type(radius, (int, np.integer))
         if radius < 0:

--- a/brainlit/utils/session.py
+++ b/brainlit/utils/session.py
@@ -203,6 +203,7 @@ class NeuroglancerSession:
             img: A 2*nx+1 X 2*ny+1 X 2*nz+1 volume.
             bounds: Bounding box object which contains the bounds of the volume.
             vox_in_img: List of coordinates which locate the initial point in the subvolume.
+            voxel: List of coordinate which locate the initial point in the whole volume.
         """
         check_type(radius, (int, np.integer))
         if radius < 0:
@@ -216,7 +217,7 @@ class NeuroglancerSession:
         img = self.pull_bounds_img(bounds)
         # img = self.cv.download(bounds, mip=self.mip)
         vox_in_img = voxel - np.array(bounds.to_list()[:3])
-        return np.squeeze(np.array(img)), bounds, vox_in_img
+        return np.squeeze(np.array(img)), bounds, vox_in_img, voxel
 
     def pull_vertex_list(
         self,


### PR DESCRIPTION
`_get_voxel()` is private but we want to access its output via a public function. Since `pull_voxel()` calls` _get_voxel()`, we can just return it there. I've updated the comments within `pull_voxel()` to reflect this as well. @FelixChihTing once this is approved, use the last output of `pull_voxel()` to get cell center coords (instead of `_get_voxel()`)