### PR TITLE
change circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,19 @@ workflows:
     jobs:
       - build-and-test
 
+commands:
+  early_return_for_forked_pull_requests:
+    description: >-
+      If this build is from a fork, stop executing the current job and return success.
+      This is useful to avoid steps that will fail due to missing credentials.
+    steps:
+      - run:
+        name: Early return if this build is from a forked PR
+        command: |
+          if [ "$CIRCLE_PR_NUMBER" ]; then
+            echo "Nothing to do for forked PRs, so marking this step successful"
+            circleci step halt
+          fi
 
 jobs:
   build-and-test:  # This is the name of the job, feel free to change it to better match what you're trying to do!
@@ -48,12 +61,17 @@ jobs:
             pip install pytest pytest-cov codecov black
             pip install -e .
       - run:
+        name: format and docs
+        command: |
+            . venv/bin/activate
+            black --check --diff ./brainlit
+            codecov
+      - early_return_for_forked_pull_requests
+      - run:
           name: run tests
           # This assumes pytest is installed via the install-package step above
           command: |
             . venv/bin/activate
             pytest --cov=brainlit brainlit/
-            black --check --diff ./brainlit
-            codecov
     
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
     # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows 
     jobs:
       - build-and-test
-
+      
 commands:
   early_return_for_forked_pull_requests:
     description: >-
@@ -21,12 +21,12 @@ commands:
       This is useful to avoid steps that will fail due to missing credentials.
     steps:
       - run:
-        name: Early return if this build is from a forked PR
-        command: |
-          if [ "$CIRCLE_PR_NUMBER" ]; then
-            echo "Nothing to do for forked PRs, so marking this step successful"
-            circleci step halt
-          fi
+          name: Early return if this build is from a forked PR
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
 
 jobs:
   build-and-test:  # This is the name of the job, feel free to change it to better match what you're trying to do!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
     # Then run your tests!
     # CircleCI will report the results back to your VCS provider.
     steps:
-      - early_return_for_forked_pull_requests
       - checkout
       - python/install-packages:
           pkg-manager: pip
@@ -61,6 +60,7 @@ jobs:
             . venv/bin/activate
             pip install pytest pytest-cov codecov black
             pip install -e .
+      - early_return_for_forked_pull_requests
       - run:
           name: run tests
           # This assumes pytest is installed via the install-package step above

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
     # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows 
     jobs:
       - build-and-test
-      
+
 commands:
   early_return_for_forked_pull_requests:
     description: >-
@@ -43,6 +43,7 @@ jobs:
     # Then run your tests!
     # CircleCI will report the results back to your VCS provider.
     steps:
+      - early_return_for_forked_pull_requests
       - checkout
       - python/install-packages:
           pkg-manager: pip
@@ -61,17 +62,12 @@ jobs:
             pip install pytest pytest-cov codecov black
             pip install -e .
       - run:
-        name: format and docs
-        command: |
-            . venv/bin/activate
-            black --check --diff ./brainlit
-            codecov
-      - early_return_for_forked_pull_requests
-      - run:
           name: run tests
           # This assumes pytest is installed via the install-package step above
           command: |
             . venv/bin/activate
             pytest --cov=brainlit brainlit/
+            black --check --diff ./brainlit
+            codecov
     
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
             pip install pytest pytest-cov codecov black
             pip install -e .
       - run:
-          name: run tests
+          name: formatting and code coverage
           # This assumes pytest is installed via the install-package step above
           command: |
             . venv/bin/activate
@@ -69,7 +69,7 @@ jobs:
             codecov
       - early_return_for_forked_pull_requests
       - run:
-          name: run tests
+          name: run pytests
           # This assumes pytest is installed via the install-package step above
           command: |
             . venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,13 @@ jobs:
             . venv/bin/activate
             pip install pytest pytest-cov codecov black
             pip install -e .
+      - run:
+          name: run tests
+          # This assumes pytest is installed via the install-package step above
+          command: |
+            . venv/bin/activate
+            black --check --diff ./brainlit
+            codecov
       - early_return_for_forked_pull_requests
       - run:
           name: run tests
@@ -67,7 +74,5 @@ jobs:
           command: |
             . venv/bin/activate
             pytest --cov=brainlit brainlit/
-            black --check --diff ./brainlit
-            codecov
     
 


### PR DESCRIPTION
incorporate early stop so forked PRs don't run tests, which need AWS credentials.